### PR TITLE
Update repository name in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,7 +4,7 @@ on: pull_request
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'tk0miya/rbs_activerecord'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'tk0miya/ruby-lsp-rbs_rails'
     steps:
       - uses: actions/create-github-app-token@v3
         id: app-token
@@ -29,7 +29,7 @@ jobs:
 
   rbs_collection:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'rbs-collection-updater[bot]' && github.repository == 'tk0miya/rbs_activerecord'
+    if: github.event.pull_request.user.login == 'rbs-collection-updater[bot]' && github.repository == 'tk0miya/ruby-lsp-rbs_rails'
     steps:
       - uses: actions/create-github-app-token@v3
         id: app-token


### PR DESCRIPTION
## Summary
Updates the GitHub Actions workflow configuration to reflect the correct repository name across auto-merge job conditions.

## Changes
- Updated repository name from `tk0miya/rbs_activerecord` to `tk0miya/ruby-lsp-rbs_rails` in the `dependabot` job condition
- Updated repository name from `tk0miya/rbs_activerecord` to `tk0miya/ruby-lsp-rbs_rails` in the `rbs_collection` job condition

## Details
The auto-merge workflow now correctly targets the renamed repository. Both the dependabot and rbs-collection-updater bot jobs will only execute when running in the correct repository context.

https://claude.ai/code/session_01FU2fQFQRC8Zj8y49FAzdoL