### PR TITLE
ci: Rename app credentials to REPO_HOUSEKEEPER

### DIFF
--- a/.github/workflows/rbs_collection.yml
+++ b/.github/workflows/rbs_collection.yml
@@ -13,8 +13,8 @@ jobs:
     - uses: actions/create-github-app-token@v3
       id: app-token
       with:
-        app-id: ${{ vars.RBS_COLLECTION_UPDATER_APP_ID }}
-        private-key: ${{ secrets.RBS_COLLECTION_UPDATER_PRIVATE_KEY }}
+        app-id: ${{ vars.REPO_HOUSEKEEPER_APP_ID }}
+        private-key: ${{ secrets.REPO_HOUSEKEEPER_PRIVATE_KEY }}
     - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1.305.0


### PR DESCRIPTION
Rename `RBS_COLLECTION_UPDATER_APP_ID` / `RBS_COLLECTION_UPDATER_PRIVATE_KEY` to `REPO_HOUSEKEEPER_APP_ID` / `REPO_HOUSEKEEPER_PRIVATE_KEY` in the RBS collection workflow.

The app is used for general repository housekeeping rather than RBS-specific work, so the credentials are unified under the REPO_HOUSEKEEPER name.