### PR TITLE
ci: declare top-level permissions in workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,6 +7,9 @@ on:
 
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     types: [labeled]
 
+permissions: {}
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
 
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/rbs_collection.yml
+++ b/.github/workflows/rbs_collection.yml
@@ -5,6 +5,9 @@ on:
     - cron: '00 8 * * MON'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Declare an explicit top-level `permissions:` block on every workflow that did not already have one, so the workflow's default `GITHUB_TOKEN` is restricted to the minimum it actually needs.

This addresses the `excessive-permissions` finding from `zizmor`. Without an explicit declaration, GitHub falls back to the repository default token permissions, which can be much broader than what the workflow uses. Pinning it at the top of the file means each job inherits a minimum baseline and a future step cannot silently gain write access just by being added.

### Per-workflow notes

- `auto-merge.yml` — does not run `actions/checkout` and the only token used is the GitHub App token (`GH_TOKEN: ${{ steps.app-token.outputs.token }}`). The workflow's `GITHUB_TOKEN` is never touched, so `permissions: {}`.
- `rbs_collection.yml` — runs `actions/checkout` (read-only) under the workflow's `GITHUB_TOKEN`; writes go through the GitHub App token in `peter-evans/create-pull-request`. So `contents: read` is enough.
- `main.yml` / `actionlint.yml` — both just `actions/checkout` + run a tool. `contents: read` is enough.
- `release.yml` — already declares its own job-level permissions (`contents: write`, `id-token: write`) for `rubygems/release-gem`, so it is intentionally not changed here.
- `dependabot-auto-label.yml` — already declares `pull-requests: read` (needed by `dependabot/fetch-metadata`), so it is intentionally not changed here.

References:
- https://docs.zizmor.sh/audits/#excessive-permissions
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

## Test plan

- [x] Run the affected workflows on this PR and confirm they still pass.