### PR TITLE
Align rake ci with the skeleton: ci task + top-level steep

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,23 +5,28 @@ require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
-task default: %i[rubocop rbs:all]
+task default: :ci
+
+task ci: %i[rubocop steep rbs:validate]
 
 namespace :rbs do
-  task all: %i[install check validate]
-
   desc "Install RBS signatures"
   task :install do
     sh "bundle exec rbs collection install --frozen"
   end
 
-  desc "Type check with Steep"
-  task :check do
-    sh "bundle exec steep check"
+  desc "Generate RBS files"
+  task :generate do
+    sh "rbs-inline", "--opt-out", "--output=sig", "lib"
   end
 
   desc "Validate RBS files"
-  task :validate do
+  task validate: "rbs:install" do
     sh "bundle exec rbs -Isig validate"
   end
+end
+
+desc "Run steep type check"
+task steep: "rbs:install" do
+  sh "bundle exec steep check"
 end


### PR DESCRIPTION
## Summary

Replaces the `rbs:all` / `rbs:check` task structure with a `ci` task (`rubocop steep rbs:validate`) as the default plus a top-level `steep` task, matching the `init-ruby-project` skeleton.

## Changes

- `Rakefile`
  - `task default: :ci`, `task ci: %i[rubocop steep rbs:validate]`
  - keep `rbs:install`; add a top-level `steep` task and an `rbs:validate` task, both depending on `rbs:install`
  - drop the `rbs:all` / `rbs:check` tasks

## Notes

- `spec` is intentionally kept out of the ci chain — this repo does not run its specs in CI today, and this PR preserves that.
- Rake dedupes prerequisites, so the collection is installed exactly once per `rake ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)