### PR TITLE
Enable the rubocop-rbs_inline plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
 plugins:
   - rubocop-rails
   - rubocop-rake
+  - rubocop-rbs_inline
   - rubocop-rspec
 
 Layout/LeadingCommentSpace:
@@ -44,6 +45,15 @@ RSpec/NestedGroups:
 
 Style/Documentation:
   Enabled: false
+
+Style/RbsInline/MissingTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RedundantTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RequireRbsInlineComment:
+  EnforcedStyle: never
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "rspec", require: false
 gem "rubocop", "~> 1.88", require: false
 gem "rubocop-rails", require: false
 gem "rubocop-rake", require: false
+gem "rubocop-rbs_inline", require: false
 gem "rubocop-rspec", require: false
 gem "ruby-lsp-rspec", require: false
 gem "steep", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,10 @@ GEM
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
+    rubocop-rbs_inline (1.5.5)
+      lint_roller (~> 1.1)
+      rbs-inline
+      rubocop (>= 1.72.1, < 2.0)
     rubocop-rspec (3.10.2)
       lint_roller (~> 1.1)
       regexp_parser (>= 2.0)
@@ -336,6 +340,7 @@ DEPENDENCIES
   rubocop (~> 1.88)
   rubocop-rails
   rubocop-rake
+  rubocop-rbs_inline
   rubocop-rspec
   ruby-lsp-rbs_rails!
   ruby-lsp-rspec

--- a/lib/ruby_lsp/rbs_rails/file_writer.rb
+++ b/lib/ruby_lsp/rbs_rails/file_writer.rb
@@ -14,6 +14,7 @@ module RubyLsp
         @path = path
       end
 
+      # @rbs content: String
       def write(content) #: void
         original_content = begin
           path.read

--- a/sig/ruby_lsp/rbs_rails/file_writer.rbs
+++ b/sig/ruby_lsp/rbs_rails/file_writer.rbs
@@ -12,7 +12,8 @@ module RubyLsp
       # @rbs path: Pathname
       def initialize: (Pathname path) -> void
 
-      def write: (untyped content) -> void
+      # @rbs content: String
+      def write: (String content) -> void
     end
   end
 end


### PR DESCRIPTION
## Summary

This gem uses rbs-inline annotations in `lib` but did not lint them. Adds the `rubocop-rbs_inline` RuboCop plugin (and its cop configuration) to match the `init-ruby-project` skeleton, so the inline type annotations are checked by `rake rubocop` / `rake ci`.

## Changes

- `Gemfile` / `Gemfile.lock`: add `rubocop-rbs_inline`
- `.rubocop.yml`
  - add `rubocop-rbs_inline` to `plugins`
  - add `Style/RbsInline/*` settings (matching the skeleton)

🤖 Generated with [Claude Code](https://claude.com/claude-code)