### PR TITLE
Introduce rubocop-numbered-params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   TargetRubyVersion: 3.2
 
 plugins:
+  - rubocop-numbered-params
   - rubocop-rails
   - rubocop-rake
   - rubocop-rbs_inline

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "rake", "~> 13.4"
 gem "rbs-inline", require: false
 gem "rspec", require: false
 gem "rubocop", "~> 1.88", require: false
+gem "rubocop-numbered-params", require: false
 gem "rubocop-rails", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rbs_inline", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,6 +259,9 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-numbered-params (1.0.0)
+      lint_roller (~> 1.0)
+      rubocop (>= 1.72.1)
     rubocop-rails (2.35.5)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
@@ -338,6 +341,7 @@ DEPENDENCIES
   rbs-inline
   rspec
   rubocop (~> 1.88)
+  rubocop-numbered-params
   rubocop-rails
   rubocop-rake
   rubocop-rbs_inline

--- a/ruby-lsp-rbs_rails.gemspec
+++ b/ruby-lsp-rbs_rails.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
     end
   end
   spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.executables = spec.files.grep(%r{\Aexe/}) { File.basename(_1) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activerecord"

--- a/spec/ruby_lsp/rbs_rails/addon_spec.rb
+++ b/spec/ruby_lsp/rbs_rails/addon_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe RubyLsp::RbsRails::Addon do
 
         context "when the model is ignored" do
           before do
-            RbsRails::CLI::Configuration.instance.ignore_model_if { |klass| klass.name == "User" }
+            RbsRails::CLI::Configuration.instance.ignore_model_if { _1.name == "User" }
           end
 
           it "generates no RBS files" do


### PR DESCRIPTION
Add the `rubocop-numbered-params` plugin to enforce a consistent style for numbered block parameters, matching the setup already used in other repositories.

- Add `rubocop-numbered-params` to the Gemfile and Gemfile.lock
- Register the plugin in `.rubocop.yml`
- Autocorrect existing offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)