### PR TITLE
Align .rubocop.yml with shared skeleton baseline

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+# NOTE: Rules are sorted in ASCII order.
+
 AllCops:
   Exclude:
     - "spec/test-app/**/*"
@@ -12,10 +14,15 @@ plugins:
   - rubocop-rbs_inline
   - rubocop-rspec
 
+# Layout
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
   AllowSteepAnnotation: true
 
+Layout/LineLength:
+  Max: 120
+
+# Metrics
 Metrics/AbcSize:
   Max: 20
 
@@ -29,14 +36,19 @@ Metrics/ClassLength:
 Metrics/MethodLength:
   Max: 30
 
+# Rails
 Rails/RakeEnvironment:
   Enabled: false
 
-RSpec/MultipleExpectations:
+# RSpec
+RSpec/ExampleLength:
   Enabled: false
 
 RSpec/MultipleMemoizedHelpers:
   Max: 10
+
+RSpec/MultipleExpectations:
+  Enabled: false
 
 RSpec/NamedSubject:
   Enabled: false
@@ -44,9 +56,7 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Max: 5
 
-Style/Documentation:
-  Enabled: false
-
+# RbsInline
 Style/RbsInline/MissingTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation
 
@@ -55,6 +65,19 @@ Style/RbsInline/RedundantTypeAnnotation:
 
 Style/RbsInline/RequireRbsInlineComment:
   EnforcedStyle: never
+
+# Style
+Style/AccessorGrouping:
+  Enabled: false
+
+Style/CommentedKeyword:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/spec/ruby_lsp/rbs_rails/addon_spec.rb
+++ b/spec/ruby_lsp/rbs_rails/addon_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RubyLsp::RbsRails::Addon do
   describe "#activate" do
     subject { described_class.new.activate(global_state, message_queue) }
 
-    let(:global_state) { instance_double(RubyLsp::GlobalState, workspace_path: workspace_path) }
+    let(:global_state) { instance_double(RubyLsp::GlobalState, workspace_path:) }
     let(:message_queue) { Thread::Queue.new }
 
     context "when Rails application is not found" do
@@ -53,7 +53,7 @@ RSpec.describe RubyLsp::RbsRails::Addon do
     end
 
     let(:addon) { described_class.new }
-    let(:global_state) { instance_double(RubyLsp::GlobalState, workspace_path: workspace_path) }
+    let(:global_state) { instance_double(RubyLsp::GlobalState, workspace_path:) }
     let(:message_queue) { Thread::Queue.new }
     let(:workspace_path) { Pathname.new(__FILE__).dirname.join("../test-app/").expand_path.to_s }
 


### PR DESCRIPTION
## Summary

Align this repository's `.rubocop.yml` with the shared `init-ruby-project`
skeleton so linting rules are consistent across all Ruby repositories, and
fix the offenses the aligned config surfaces.

## Config changes

- Add `Layout/LineLength`, `RSpec/ExampleLength`, `Style/AccessorGrouping`,
  `Style/CommentedKeyword`, `Style/HashSyntax`
- Rules sorted in ASCII order to match the skeleton

Project-specific extensions (`AllCops/Exclude`, `rubocop-rails` plugin,
`Rails/RakeEnvironment`, `Metrics/ClassLength`, `Metrics/BlockLength`
exclude) are preserved.

## Code changes (offenses surfaced by the new cops)

- `addon_spec.rb`: use `key:` value shorthand (`Style/HashSyntax`)

Verified locally with `rubocop` (bundle matching the lockfile) — no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)