### PR TITLE
Set up dev-workflow hooks

### DIFF
--- a/.claude/hooks/self-review.sh
+++ b/.claude/hooks/self-review.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# PreToolUse hook: review code before `git commit`.
+#
+# Fires before a Bash `git commit` command and blocks the first commit attempt
+# for a given change-set, asking Claude to review the code before committing.
+# The review uses the `self-review` skill when available, and falls back to the
+# bundled `code-review` skill otherwise — so the hook works even in projects
+# that don't ship the custom self-review skill.
+#
+# A per-change-set marker (keyed by a hash of the diff, stored under .git/)
+# prevents an infinite block loop: once a change-set has been surfaced for
+# review, the matching commit is allowed through. If the review leads to fixes,
+# the diff changes, so the new state is reviewed once more before it commits.
+#
+
+set -euo pipefail
+
+# Read JSON input from stdin
+input=$(cat)
+
+tool_name=$(echo "$input" | jq -r '.tool_name // empty')
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+# Only gate the Bash tool running a git commit.
+if [[ "$tool_name" != "Bash" ]]; then
+  exit 0
+fi
+# Match the `commit` subcommand, allowing an optional `git -C <path>` prefix
+# (the convention the self-review skill uses for worktrees). Other git global
+# options before the subcommand are unlikely here and intentionally not handled.
+# `git` must sit at a command boundary (start of the string, or after a shell
+# separator) so that a literal "git commit" inside an echo/grep argument does
+# not trigger the hook. The pattern lives in a variable so `[[` does not try to
+# parse its parentheses as shell syntax.
+commit_re='(^|[;&|(])[[:space:]]*git[[:space:]]+(-C[[:space:]]+[^[:space:]]+[[:space:]]+)?commit([[:space:]]|$)'
+if [[ ! "$command" =~ $commit_re ]]; then
+  exit 0
+fi
+
+# If the command targets a specific repo via `git -C <path>`, operate there too.
+work_dir="."
+if [[ "$command" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  work_dir="${BASH_REMATCH[1]}"
+fi
+
+# Not a git repo → nothing to do.
+git_dir=$(git -C "$work_dir" rev-parse --absolute-git-dir 2>/dev/null || true)
+if [[ -z "$git_dir" ]]; then
+  exit 0
+fi
+
+# Hash the changes about to be committed. `git diff HEAD` covers both
+# `git add` + commit and `git commit -a`. Before the first commit HEAD is
+# absent, so fall back to the working state.
+if git -C "$work_dir" rev-parse --verify HEAD >/dev/null 2>&1; then
+  changeset=$(git -C "$work_dir" diff HEAD)
+else
+  changeset=$(git -C "$work_dir" status --porcelain; git -C "$work_dir" diff; git -C "$work_dir" diff --cached)
+fi
+
+# Nothing to review (e.g. a message-only `--amend`) → let it proceed.
+if [[ -z "$changeset" ]]; then
+  exit 0
+fi
+
+hash=$(printf '%s' "$changeset" | git hash-object --stdin)
+state_file="$git_dir/self-review-reviewed"
+
+# Already surfaced for review → allow the commit.
+if [[ -f "$state_file" ]] && grep -qxF "$hash" "$state_file"; then
+  exit 0
+fi
+
+# Record this change-set and block once to force a review first.
+echo "$hash" >> "$state_file"
+
+review_prompt='SELF-REVIEW REQUIRED before committing. Review the changes that are
+about to be committed BEFORE running git commit again:
+
+- If the `self-review` skill is available, invoke it (Skill tool, skill "self-review").
+- Otherwise, run the bundled `/code-review` skill on the working diff.
+
+If the review finds issues, fix them and review again. Once it is clean, run the same
+git commit command again to proceed — it will be allowed through.'
+
+jq -n --arg reason "$review_prompt" '{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": $reason
+  }
+}'
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "allow": ["RemoteTrigger"]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/self-review.sh",
+            "timeout": 10000
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Install the `setup-dev-workflow-hooks` skill in this repository:

- `.claude/hooks/self-review.sh` — a PreToolUse hook that runs a code review before `git commit` (replaces the older copy of this hook).
- `.claude/settings.json` — wires up the hook and allows the `RemoteTrigger` permission ("send later") by default.

This brings the repo in line with the shared dev-workflow skeleton.