### PR TITLE
chore: catch up with the shared Ruby skeleton

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,4 @@
 {
-  "permissions": {
-    "allow": ["RemoteTrigger"]
-  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,11 @@ on:
     branches:
       - main
     paths:
-      - 'lib/rbs_activerecord/version.rb'
+      - 'lib/ruby_lsp/rbs_rails/version.rb'
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   release:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,27 +44,17 @@ Rails/RakeEnvironment:
 RSpec/ExampleLength:
   Enabled: false
 
-RSpec/MultipleMemoizedHelpers:
-  Max: 10
-
 RSpec/MultipleExpectations:
   Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
 
 RSpec/NamedSubject:
   Enabled: false
 
 RSpec/NestedGroups:
   Max: 5
-
-# RbsInline
-Style/RbsInline:
-  Mode: opt_out
-
-Style/RbsInline/MissingTypeAnnotation:
-  EnforcedStyle: doc_style_and_return_annotation
-
-Style/RbsInline/RedundantTypeAnnotation:
-  EnforcedStyle: doc_style_and_return_annotation
 
 # Style
 Style/AccessorGrouping:
@@ -78,6 +68,15 @@ Style/Documentation:
 
 Style/HashSyntax:
   EnforcedShorthandSyntax: always
+
+Style/RbsInline:
+  Mode: opt_out
+
+Style/RbsInline/MissingTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RedundantTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/Rakefile
+++ b/Rakefile
@@ -10,14 +10,23 @@ task default: :ci
 task ci: %i[rubocop steep rbs:validate]
 
 namespace :rbs do
-  desc "Install RBS signatures"
+  # sig/gems holds hand-written types for external gems, so it is never regenerated
+  kept = ->(path) { path == "sig/gems" || path.start_with?("sig/gems/") }
+
+  desc "Install RBS collection"
   task :install do
     sh "bundle exec rbs collection install --frozen"
   end
 
-  desc "Generate RBS files"
-  task :generate do
-    sh "rbs-inline", "--opt-out", "--output=sig", "lib"
+  desc "Regenerate all RBS files under sig/ from scratch (run manually after editing lib/)"
+  task :regenerate do
+    Dir.glob("sig/**/*.rbs").reject(&kept).each { rm _1 }
+
+    sh "bundle exec rbs-inline --opt-out --output=sig lib"
+
+    # Drop the directories the deletion above left empty, deepest first
+    dirs = Dir.glob("sig/**/*").select { File.directory?(_1) }
+    dirs.reject(&kept).sort.reverse_each { rmdir _1 if Dir.empty?(_1) }
   end
 
   desc "Validate RBS files"


### PR DESCRIPTION
## Summary

Same sweep as tk0miya/not_nilable#43, applied to this repository. Three commits, one topic each.

## `chore: replace rbs:generate with rbs:regenerate`

`rbs:generate` overwrote signatures in place, so a signature whose `lib/` source was deleted stayed behind in `sig/` forever. `rbs:regenerate` deletes the generated tree first and regenerates from scratch, keeping the hand-written `sig/gems/` stubs.

Only the `rbs` namespace is taken from the skeleton — this project has no spec suite, so `ci` and the absent RSpec rake task stay as they are.

## `chore: drop the ineffective RemoteTrigger permission rule`

`RemoteTrigger` was never a real permission rule name. Upstream tried the actual MCP tool identifiers, verified those had no effect either, and removed the block entirely.

## `ci: fix the release trigger path and declare workflow permissions`

**`release.yml` watched `lib/rbs_activerecord/version.rb`** — a path belonging to a different gem, which does not exist in this repository. Pushing a version bump therefore never triggered a release; only a manual `workflow_dispatch` did. It now points at `lib/ruby_lsp/rbs_rails/version.rb`, where this gem's version actually lives. Found while adding the missing top-level `permissions` block to that same file.

`.rubocop.yml` ordering is fixed in the same commit: ASCII order was violated by `RSpec/MultipleMemoizedHelpers` preceding `RSpec/MultipleExpectations`, and by the `Style/RbsInline` section sitting ahead of `Style/`. No cop configuration changes.

## Verification

Run locally against this branch:

- `bundle exec rake rbs:regenerate` — regenerates 5 signatures and leaves `sig/` **unchanged**, so the task is idempotent here.
- `bundle exec rake ci` — passes: rubocop, steep ("No type error detected"), `rbs:validate`.
- `actionlint` — passes.
- `.claude/hooks/self-review.sh` is identical to the skill template, and every pinned action SHA was checked against the `tags` API.

No test cases were added: this repository has no spec suite, and the changes are build, lint and CI configuration.

## Out of scope

This repository has never had `setup-ruby-hooks` applied — `.claude/hooks/` holds only `self-review.sh`, so there is no `protect-sig-files.sh` / `pre-commit-check.sh` / `rbs-inline.sh` to update here. Adopting them is a separate task, to be handled after this sweep lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)