### PR TITLE
Introduce rubocop-rspec-unused-let

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ plugins:
   - rubocop-rake
   - rubocop-rbs_inline
   - rubocop-rspec
+  - rubocop-rspec-unused-let
 
 # Layout
 Layout/LeadingCommentSpace:

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "rubocop-rails", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rbs_inline", require: false
 gem "rubocop-rspec", require: false
+gem "rubocop-rspec-unused-let", require: false
 gem "ruby-lsp-rspec", require: false
 gem "steep", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,10 @@ GEM
       lint_roller (~> 1.1)
       regexp_parser (>= 2.0)
       rubocop (~> 1.86, >= 1.86.2)
+    rubocop-rspec-unused-let (1.2.0)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72)
+      rubocop-rspec (~> 3.0)
     ruby-lsp (0.26.10)
       language_server-protocol (~> 3.17.0)
       prism (>= 1.2, < 2.0)
@@ -346,6 +350,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rbs_inline
   rubocop-rspec
+  rubocop-rspec-unused-let
   ruby-lsp-rbs_rails!
   ruby-lsp-rspec
   sqlite3 (>= 2.1)

--- a/spec/ruby_lsp/rbs_rails/file_writer_spec.rb
+++ b/spec/ruby_lsp/rbs_rails/file_writer_spec.rb
@@ -13,13 +13,15 @@ RSpec.describe RubyLsp::RbsRails::FileWriter do
     let(:tmpdir) { Pathname.new(Dir.mktmpdir("file_writer_test")) }
 
     context "when the file does not exist" do
+      let(:content) { "class NewClass; end" }
+
       it "creates the file with the given content" do
         expect(path).not_to exist
 
-        file_writer.write("class NewClass; end")
+        subject
 
         expect(path).to exist
-        expect(path.read).to eq("class NewClass; end")
+        expect(path.read).to eq(content)
       end
     end
 
@@ -31,11 +33,13 @@ RSpec.describe RubyLsp::RbsRails::FileWriter do
       let(:old_content) { "class ExistingClass; end" }
 
       context "when the content is different" do
+        let(:content) { "class NewClass; end" }
+
         it "updates the file with the new content" do
-          file_writer.write("class NewClass; end")
+          subject
 
           expect(path).to exist
-          expect(path.read).to eq("class NewClass; end")
+          expect(path.read).to eq(content)
         end
       end
 
@@ -44,10 +48,11 @@ RSpec.describe RubyLsp::RbsRails::FileWriter do
           path.utime(mtime, mtime)
         end
 
+        let(:content) { old_content }
         let(:mtime) { Time.zone.now - 60 }
 
         it "does not modify the file" do
-          file_writer.write(old_content)
+          subject
 
           expect(path).to exist
           expect(path.read).to eq(old_content)


### PR DESCRIPTION
Adds [rubocop-rspec-unused-let](https://github.com/tk0miya/rubocop-rspec-unused-let) and enables its `RSpec/UnusedLet` cop, which flags `let`/`subject` definitions and helper methods that are never referenced.

## The one offense it found

`spec/ruby_lsp/rbs_rails/file_writer_spec.rb` declares the action under test as a subject, the way `logger_spec.rb` and `addon_spec.rb` do:

```ruby
subject { file_writer.write(content) }
```

but no example ever invokes it. Each one calls `file_writer.write` directly with a literal instead, so the subject went unreferenced and the `content` it names was never defined anywhere in the file.

The fix wires the examples up to the subject rather than dropping it: each context now declares the `content` it exercises, and the examples call `subject`. That also removes the duplicated literals the assertions were repeating.

## Review note

Two of the three examples were verified to pass locally. The third still fails, for a reason this PR does not touch: its `before` hook calls `path.utime(mtime, mtime)` with `Time.zone.now - 60`, and `Pathname#utime` rejects an `ActiveSupport::TimeWithZone` (`TypeError: can't convert ActiveSupport::TimeWithZone into time`).

Verifying at all needed `tmpdir`, `pathname`, `active_support` and `ruby_lsp/rbs_rails/file_writer` to be required ad hoc from the command line — the spec file requires none of them, unlike `logger_spec.rb`, so it raises `uninitialized constant RubyLsp::RbsRails::FileWriter` on its own. None of this is new: `rake ci` runs `rubocop`, `steep` and `rbs:validate` and never RSpec, so the spec suite is not exercised in CI. Left alone here as separate from introducing the cop, but worth a follow-up.

## Note on the resolved version

`Gemfile.lock` pins 1.2.0 rather than the latest 1.3.0 because of the 7-day `cooldown` on the RubyGems source. That makes no difference here: both versions report exactly this one offense for this repository. Dependabot will bump it once the cooldown window passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)